### PR TITLE
Add example for multiple top level APIs

### DIFF
--- a/examples/multiple-apis/main.go
+++ b/examples/multiple-apis/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"github.com/calvinmclean/babyapi"
+	"github.com/go-chi/chi/v5"
+	"log/slog"
+	"net/http"
+)
+
+type TODO struct {
+	babyapi.DefaultResource
+
+	Title       string
+	Description string
+	Completed   bool
+}
+
+type GOAL struct {
+	babyapi.DefaultResource
+
+	Title       string
+	Description string
+	Completed   bool
+}
+
+// RoutableAPI defines a minimum interface to register APIs to the router, along with displaying usable logs.
+type RoutableAPI interface {
+	Route(chi.Router)
+	Name() string
+}
+
+// Takes an addr string same as http.ListenAndServe and one or more APIs and will serve all of them.
+// The APIs must not have conflicting base routes.
+// This does not allow CLI functionality.
+func serveAll(addr string, apis ...RoutableAPI) {
+	router := chi.NewRouter()
+	for _, api := range apis {
+		slog.Info("Setting up API", api.Name())
+		api.Route(router)
+	}
+	slog.Info("starting server", "address", addr)
+	err := http.ListenAndServe(addr, router)
+	if err != nil && err != http.ErrServerClosed {
+		slog.Error("server shutdown error", "error", err)
+	}
+}
+
+func main() {
+	TodoApi := babyapi.NewAPI[*TODO]("TODOs", "/todos", func() *TODO { return &TODO{} })
+	GoalApi := babyapi.NewAPI[*GOAL]("GOALs", "/goals", func() *GOAL { return &GOAL{} })
+
+	serveAll(":3000", TodoApi, GoalApi)
+}


### PR DESCRIPTION
I created an example for people who want to have more than one top level API, not just children. As far as I can tell the only major drawback is that the does not preserve CLI functionality. Happy to make any changes needed for code style or anything else to make it better fit or more understandable. 