### PR TITLE
Add new bindip argument to CLI for serve

### DIFF
--- a/babyapi_test.go
+++ b/babyapi_test.go
@@ -540,7 +540,7 @@ func TestCLI(t *testing.T) {
 	songAPI := babyapi.NewAPI[*Song]("Songs", "/songs", func() *Song { return &Song{} })
 	api.AddNestedAPI(songAPI)
 	go func() {
-		err := api.RunWithArgs(os.Stdout, []string{"serve"}, 8080, "localhost", "", false, nil, "")
+		err := api.RunWithArgs(os.Stdout, []string{"serve"}, "localhost:8080", "", false, nil, "")
 		require.NoError(t, err)
 	}()
 
@@ -573,14 +573,14 @@ func TestCLI(t *testing.T) {
 	t.Run("GetAllQueryParams", func(t *testing.T) {
 		t.Run("Successful", func(t *testing.T) {
 			var out bytes.Buffer
-			err := api.RunWithArgs(&out, []string{"list", "Albums"}, 0, "", address, false, nil, "title=New Album")
+			err := api.RunWithArgs(&out, []string{"list", "Albums"}, "", address, false, nil, "title=New Album")
 			require.NoError(t, err)
 			require.Equal(t, `{"items":[{"id":"cljcqg5o402e9s28rbp0","title":"New Album"}]}`, strings.TrimSpace(out.String()))
 		})
 
 		t.Run("NoMatch", func(t *testing.T) {
 			var out bytes.Buffer
-			err := api.RunWithArgs(&out, []string{"list", "Albums"}, 0, "", address, false, nil, "title=badTitle")
+			err := api.RunWithArgs(&out, []string{"list", "Albums"}, "", address, false, nil, "title=badTitle")
 			require.NoError(t, err)
 			require.Equal(t, `{"items":[]}`, strings.TrimSpace(out.String()))
 		})
@@ -589,7 +589,7 @@ func TestCLI(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var out bytes.Buffer
-			err := api.RunWithArgs(&out, tt.args, 0, "", address, false, nil, "")
+			err := api.RunWithArgs(&out, tt.args, "", address, false, nil, "")
 			if !tt.expectedErr {
 				require.NoError(t, err)
 				require.Regexp(t, tt.expectedRegexp, strings.TrimSpace(out.String()))
@@ -927,7 +927,7 @@ func TestRootAPIAsChildOfResourceAPI(t *testing.T) {
 	artistAPI.AddNestedAPI(rootAPI)
 
 	go func() {
-		err := artistAPI.RunWithArgs(os.Stdout, []string{"serve"}, 8080, "localhost", "", false, nil, "")
+		err := artistAPI.RunWithArgs(os.Stdout, []string{"serve"}, "localhost:8080", "", false, nil, "")
 		require.NoError(t, err)
 	}()
 
@@ -942,14 +942,14 @@ func TestRootAPIAsChildOfResourceAPI(t *testing.T) {
 
 	t.Run("TestGetAllSongsEmpty", func(t *testing.T) {
 		var out bytes.Buffer
-		err := artistAPI.RunWithArgs(&out, []string{"list", "Songs", artist1.GetID()}, 0, "", address, false, nil, "")
+		err := artistAPI.RunWithArgs(&out, []string{"list", "Songs", artist1.GetID()}, "", address, false, nil, "")
 		require.NoError(t, err)
 		require.Regexp(t, `{"items":\[\]}`, strings.TrimSpace(out.String()))
 	})
 
 	t.Run("CreateSong", func(t *testing.T) {
 		var out bytes.Buffer
-		err := artistAPI.RunWithArgs(&out, []string{"post", "Songs", `{"title": "new song"}`, artist1.GetID()}, 0, "", address, false, nil, "")
+		err := artistAPI.RunWithArgs(&out, []string{"post", "Songs", `{"title": "new song"}`, artist1.GetID()}, "", address, false, nil, "")
 		require.NoError(t, err)
 		require.Regexp(t, `\{"id":"[0-9a-v]{20}","title":"new song"\}`, strings.TrimSpace(out.String()))
 	})
@@ -1120,7 +1120,7 @@ func TestRootAPICLI(t *testing.T) {
 				AddNestedAPI(songAPI)
 
 			go func() {
-				err := rootAPI.RunWithArgs(os.Stdout, []string{"serve"}, 8080, "localhost", "", false, nil, "")
+				err := rootAPI.RunWithArgs(os.Stdout, []string{"serve"}, "localhost:8080", "", false, nil, "")
 				require.NoError(t, err)
 			}()
 
@@ -1155,14 +1155,14 @@ func TestRootAPICLI(t *testing.T) {
 			t.Run("GetAllQueryParams", func(t *testing.T) {
 				t.Run("Successful", func(t *testing.T) {
 					var out bytes.Buffer
-					err := rootAPI.RunWithArgs(&out, []string{"list", "MusicVideos"}, 0, "", address, false, nil, "title=New Video")
+					err := rootAPI.RunWithArgs(&out, []string{"list", "MusicVideos"}, "", address, false, nil, "title=New Video")
 					require.NoError(t, err)
 					require.Equal(t, `{"items":[{"id":"cljcqg5o402e9s28rbp0","title":"New Video"}]}`, strings.TrimSpace(out.String()))
 				})
 
 				t.Run("NoMatch", func(t *testing.T) {
 					var out bytes.Buffer
-					err := rootAPI.RunWithArgs(&out, []string{"list", "MusicVideos"}, 0, "", address, false, nil, "title=badTitle")
+					err := rootAPI.RunWithArgs(&out, []string{"list", "MusicVideos"}, "", address, false, nil, "title=badTitle")
 					require.NoError(t, err)
 					require.Equal(t, `{"items":[]}`, strings.TrimSpace(out.String()))
 				})
@@ -1171,7 +1171,7 @@ func TestRootAPICLI(t *testing.T) {
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
 					var out bytes.Buffer
-					err := rootAPI.RunWithArgs(&out, tt.args, 0, "", address, false, nil, "")
+					err := rootAPI.RunWithArgs(&out, tt.args, "", address, false, nil, "")
 					if !tt.expectedErr {
 						require.NoError(t, err)
 						require.Regexp(t, tt.expectedRegexp, strings.TrimSpace(out.String()))

--- a/babyapi_test.go
+++ b/babyapi_test.go
@@ -540,7 +540,7 @@ func TestCLI(t *testing.T) {
 	songAPI := babyapi.NewAPI[*Song]("Songs", "/songs", func() *Song { return &Song{} })
 	api.AddNestedAPI(songAPI)
 	go func() {
-		err := api.RunWithArgs(os.Stdout, []string{"serve"}, 8080, "", false, nil, "")
+		err := api.RunWithArgs(os.Stdout, []string{"serve"}, 8080, "localhost", "", false, nil, "")
 		require.NoError(t, err)
 	}()
 
@@ -573,14 +573,14 @@ func TestCLI(t *testing.T) {
 	t.Run("GetAllQueryParams", func(t *testing.T) {
 		t.Run("Successful", func(t *testing.T) {
 			var out bytes.Buffer
-			err := api.RunWithArgs(&out, []string{"list", "Albums"}, 0, address, false, nil, "title=New Album")
+			err := api.RunWithArgs(&out, []string{"list", "Albums"}, 0, "", address, false, nil, "title=New Album")
 			require.NoError(t, err)
 			require.Equal(t, `{"items":[{"id":"cljcqg5o402e9s28rbp0","title":"New Album"}]}`, strings.TrimSpace(out.String()))
 		})
 
 		t.Run("NoMatch", func(t *testing.T) {
 			var out bytes.Buffer
-			err := api.RunWithArgs(&out, []string{"list", "Albums"}, 0, address, false, nil, "title=badTitle")
+			err := api.RunWithArgs(&out, []string{"list", "Albums"}, 0, "", address, false, nil, "title=badTitle")
 			require.NoError(t, err)
 			require.Equal(t, `{"items":[]}`, strings.TrimSpace(out.String()))
 		})
@@ -589,7 +589,7 @@ func TestCLI(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var out bytes.Buffer
-			err := api.RunWithArgs(&out, tt.args, 0, address, false, nil, "")
+			err := api.RunWithArgs(&out, tt.args, 0, "", address, false, nil, "")
 			if !tt.expectedErr {
 				require.NoError(t, err)
 				require.Regexp(t, tt.expectedRegexp, strings.TrimSpace(out.String()))
@@ -927,7 +927,7 @@ func TestRootAPIAsChildOfResourceAPI(t *testing.T) {
 	artistAPI.AddNestedAPI(rootAPI)
 
 	go func() {
-		err := artistAPI.RunWithArgs(os.Stdout, []string{"serve"}, 8080, "", false, nil, "")
+		err := artistAPI.RunWithArgs(os.Stdout, []string{"serve"}, 8080, "localhost", "", false, nil, "")
 		require.NoError(t, err)
 	}()
 
@@ -942,14 +942,14 @@ func TestRootAPIAsChildOfResourceAPI(t *testing.T) {
 
 	t.Run("TestGetAllSongsEmpty", func(t *testing.T) {
 		var out bytes.Buffer
-		err := artistAPI.RunWithArgs(&out, []string{"list", "Songs", artist1.GetID()}, 0, address, false, nil, "")
+		err := artistAPI.RunWithArgs(&out, []string{"list", "Songs", artist1.GetID()}, 0, "", address, false, nil, "")
 		require.NoError(t, err)
 		require.Regexp(t, `{"items":\[\]}`, strings.TrimSpace(out.String()))
 	})
 
 	t.Run("CreateSong", func(t *testing.T) {
 		var out bytes.Buffer
-		err := artistAPI.RunWithArgs(&out, []string{"post", "Songs", `{"title": "new song"}`, artist1.GetID()}, 0, address, false, nil, "")
+		err := artistAPI.RunWithArgs(&out, []string{"post", "Songs", `{"title": "new song"}`, artist1.GetID()}, 0, "", address, false, nil, "")
 		require.NoError(t, err)
 		require.Regexp(t, `\{"id":"[0-9a-v]{20}","title":"new song"\}`, strings.TrimSpace(out.String()))
 	})
@@ -1120,7 +1120,7 @@ func TestRootAPICLI(t *testing.T) {
 				AddNestedAPI(songAPI)
 
 			go func() {
-				err := rootAPI.RunWithArgs(os.Stdout, []string{"serve"}, 8080, "", false, nil, "")
+				err := rootAPI.RunWithArgs(os.Stdout, []string{"serve"}, 8080, "localhost", "", false, nil, "")
 				require.NoError(t, err)
 			}()
 
@@ -1155,14 +1155,14 @@ func TestRootAPICLI(t *testing.T) {
 			t.Run("GetAllQueryParams", func(t *testing.T) {
 				t.Run("Successful", func(t *testing.T) {
 					var out bytes.Buffer
-					err := rootAPI.RunWithArgs(&out, []string{"list", "MusicVideos"}, 0, address, false, nil, "title=New Video")
+					err := rootAPI.RunWithArgs(&out, []string{"list", "MusicVideos"}, 0, "", address, false, nil, "title=New Video")
 					require.NoError(t, err)
 					require.Equal(t, `{"items":[{"id":"cljcqg5o402e9s28rbp0","title":"New Video"}]}`, strings.TrimSpace(out.String()))
 				})
 
 				t.Run("NoMatch", func(t *testing.T) {
 					var out bytes.Buffer
-					err := rootAPI.RunWithArgs(&out, []string{"list", "MusicVideos"}, 0, address, false, nil, "title=badTitle")
+					err := rootAPI.RunWithArgs(&out, []string{"list", "MusicVideos"}, 0, "", address, false, nil, "title=badTitle")
 					require.NoError(t, err)
 					require.Equal(t, `{"items":[]}`, strings.TrimSpace(out.String()))
 				})
@@ -1171,7 +1171,7 @@ func TestRootAPICLI(t *testing.T) {
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
 					var out bytes.Buffer
-					err := rootAPI.RunWithArgs(&out, tt.args, 0, address, false, nil, "")
+					err := rootAPI.RunWithArgs(&out, tt.args, 0, "", address, false, nil, "")
 					if !tt.expectedErr {
 						require.NoError(t, err)
 						require.Regexp(t, tt.expectedRegexp, strings.TrimSpace(out.String()))

--- a/cli.go
+++ b/cli.go
@@ -28,14 +28,12 @@ func (ssf *stringSliceFlag) Set(value string) error {
 }
 
 func (a *API[T]) RunCLI() {
-	var port int
-	var bindip string
+	var bindAddress string
 	var address string
 	var pretty bool
 	var headers stringSliceFlag
 	var query string
-	flag.IntVar(&port, "port", 8080, "http port for server")
-	flag.StringVar(&bindip, "bindip", "", "IP address or hostname to bind server to")
+	flag.StringVar(&bindAddress, "bindAddress", "", "Address and port to bind to for example :8080 for port only, localhost:8080 or 172.0.0.1:8080")
 	flag.StringVar(&address, "address", "http://localhost:8080", "server address for client")
 	flag.BoolVar(&pretty, "pretty", true, "pretty print JSON if enabled")
 	flag.Var(&headers, "H", "add headers to request")
@@ -45,19 +43,19 @@ func (a *API[T]) RunCLI() {
 
 	args := flag.Args()
 
-	err := a.RunWithArgs(os.Stdout, args, port, bindip, address, pretty, headers, query)
+	err := a.RunWithArgs(os.Stdout, args, bindAddress, address, pretty, headers, query)
 	if err != nil {
 		fmt.Printf("error: %v\n", err)
 	}
 }
 
-func (a *API[T]) RunWithArgs(out io.Writer, args []string, port int, bindip string, address string, pretty bool, headers []string, query string) error {
+func (a *API[T]) RunWithArgs(out io.Writer, args []string, bindAddress string, address string, pretty bool, headers []string, query string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("at least one argument required")
 	}
 
 	if args[0] == "serve" {
-		a.Serve(fmt.Sprintf("%s:%d", bindip, port))
+		a.Serve(bindAddress)
 		return nil
 	}
 

--- a/cli.go
+++ b/cli.go
@@ -29,11 +29,13 @@ func (ssf *stringSliceFlag) Set(value string) error {
 
 func (a *API[T]) RunCLI() {
 	var port int
+	var bindip string
 	var address string
 	var pretty bool
 	var headers stringSliceFlag
 	var query string
 	flag.IntVar(&port, "port", 8080, "http port for server")
+	flag.StringVar(&bindip, "bindip", "", "IP address or hostname to bind server to")
 	flag.StringVar(&address, "address", "http://localhost:8080", "server address for client")
 	flag.BoolVar(&pretty, "pretty", true, "pretty print JSON if enabled")
 	flag.Var(&headers, "H", "add headers to request")
@@ -43,19 +45,19 @@ func (a *API[T]) RunCLI() {
 
 	args := flag.Args()
 
-	err := a.RunWithArgs(os.Stdout, args, port, address, pretty, headers, query)
+	err := a.RunWithArgs(os.Stdout, args, port, bindip, address, pretty, headers, query)
 	if err != nil {
 		fmt.Printf("error: %v\n", err)
 	}
 }
 
-func (a *API[T]) RunWithArgs(out io.Writer, args []string, port int, address string, pretty bool, headers []string, query string) error {
+func (a *API[T]) RunWithArgs(out io.Writer, args []string, port int, bindip string, address string, pretty bool, headers []string, query string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("at least one argument required")
 	}
 
 	if args[0] == "serve" {
-		a.Serve(fmt.Sprintf(":%d", port))
+		a.Serve(fmt.Sprintf("%s:%d", bindip, port))
 		return nil
 	}
 


### PR DESCRIPTION
This allows binding to a specific IP on a machine with multiple IP addresses, or binding only to localhost when running for local use such as with a reverse proxy or for testing.

Also update all tests for the new method signature. either passing an empty string when nothing will be served, or localhost when serve is used.

I am sorry that I have not added any new tests here, but I'm not entirely sure how to create any kind of useful test for this feature, and it is fortunately extremely simple in it's implementation. It does work as expected in my manual testing.

-----

I find this particularly useful as I often do development on a Mac which causes a security popup anytime a new executable attempts to bind to any non-loopback address, and since go in compiled that is every time I make any change.

Also I often work in environments with multiple IP addresses per machine and want to allow applications only to listen on specific IP addresses. This can be because multiple applications want to use the same port number, or just for security reasons like adding stunnel to wrap an API in HTTPS