### PR TITLE
Change test to bind only on localhost

### DIFF
--- a/babyapi_test.go
+++ b/babyapi_test.go
@@ -64,7 +64,7 @@ func TestBabyAPI(t *testing.T) {
 
 	album1 := &Album{Title: "Album1"}
 
-	go api.Serve(":8080")
+	go api.Serve("localhost:8080")
 	serverURL := "http://localhost:8080"
 
 	client := api.Client(serverURL)


### PR DESCRIPTION
This is related to issues I mentioned on pr #28 but since this was not dependent on the code in that PR I created it as a separate one.


This is mainly to help with the issue when running tests on a mac where any application attempting to bind to anything other than the loopback or localhost address will cause a security alert. In practice this means that the tests always fail the first time as all traffic is blocked until the user is able to manually respond to the popup. On a second run of the tests it will still work.

without merging #28 it still causes a security popup, but this PR does fix it failing on the first run since the tests with serve don't attempt to connect.