### PR TITLE
Replace shared chan with broadcast channel on SSE

### DIFF
--- a/babyapi_test.go
+++ b/babyapi_test.go
@@ -733,14 +733,17 @@ func TestServerSentEvents(t *testing.T) {
 	})
 
 	t.Run("GetServerSentEventsEndpoint", func(t *testing.T) {
+		testActive := true
 		go func() {
-			events <- &babyapi.ServerSentEvent{
-				Event: "event",
-				Data:  "hello",
+			for testActive {
+				events <- &babyapi.ServerSentEvent{
+					Event: "event",
+					Data:  "hello",
+				}
 			}
 		}()
-
 		response, err := http.Get(address + "/items/events")
+		testActive = false
 		require.NoError(t, err)
 		defer response.Body.Close()
 

--- a/babyapi_test.go
+++ b/babyapi_test.go
@@ -733,17 +733,22 @@ func TestServerSentEvents(t *testing.T) {
 	})
 
 	t.Run("GetServerSentEventsEndpoint", func(t *testing.T) {
-		testActive := true
+		quitTest := make(chan bool)
 		go func() {
-			for testActive {
-				events <- &babyapi.ServerSentEvent{
-					Event: "event",
-					Data:  "hello",
+			for {
+				select {
+				case <-quitTest:
+					return
+				default:
+					events <- &babyapi.ServerSentEvent{
+						Event: "event",
+						Data:  "hello",
+					}
 				}
 			}
 		}()
 		response, err := http.Get(address + "/items/events")
-		testActive = false
+		quitTest <- true
 		require.NoError(t, err)
 		defer response.Body.Close()
 

--- a/helpers.go
+++ b/helpers.go
@@ -7,7 +7,6 @@ import (
 	"html/template"
 	"net/http"
 	"strings"
-	"sync"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
@@ -174,106 +173,6 @@ func (a *API[T]) GetRequestedResource(r *http.Request) (T, *ErrResponse) {
 	}
 
 	return resource, nil
-}
-
-type BroadcastChannel[T any] struct {
-	listeners []chan T
-	lock      sync.RWMutex
-}
-
-func (bc *BroadcastChannel[T]) GetListener() chan T {
-	bc.lock.Lock()
-	defer bc.lock.Unlock()
-	newChan := make(chan T)
-	bc.listeners = append(bc.listeners, newChan)
-	return newChan
-}
-
-func (bc *BroadcastChannel[T]) RemoveListener(removeChan chan T) {
-	bc.lock.Lock()
-	defer bc.lock.Unlock()
-	for i, listener := range bc.listeners {
-		if listener == removeChan {
-			bc.listeners[i] = bc.listeners[len(bc.listeners)-1]
-			bc.listeners = bc.listeners[:len(bc.listeners)-1]
-			close(listener)
-			return
-		}
-	}
-}
-
-func (bc *BroadcastChannel[T]) SendToAll(input T) {
-	bc.lock.RLock()
-	defer bc.lock.RUnlock()
-	for _, listener := range bc.listeners {
-		listener <- input
-	}
-}
-
-func (bc *BroadcastChannel[T]) runInputChannel(inputChan chan T) {
-	for input := range inputChan {
-		bc.SendToAll(input)
-	}
-}
-
-// GetInputChannel returns a channel acting as an input to the broadcast channel, closing the channel will stop the worker goroutine
-func (bc *BroadcastChannel[T]) GetInputChannel() chan T {
-	newInputChan := make(chan T)
-	go bc.runInputChannel(newInputChan)
-	return newInputChan
-}
-
-// ServerSentEvent is a simple struct that represents an event used in HTTP event stream
-type ServerSentEvent struct {
-	Event string
-	Data  string
-}
-
-// Write will write the ServerSentEvent to the HTTP response stream and flush. It removes all newlines
-// in the event data
-func (sse *ServerSentEvent) Write(w http.ResponseWriter) {
-	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", sse.Event, strings.ReplaceAll(sse.Data, "\n", ""))
-	if f, ok := w.(http.Flusher); ok {
-		f.Flush()
-	}
-}
-
-// AddServerSentEventHandler is a shortcut for HandleServerSentEvents that automatically creates and returns
-// the events channel and adds a custom handler for GET requests matching the provided pattern
-func (a *API[T]) AddServerSentEventHandler(pattern string) chan *ServerSentEvent {
-	eventsBroadcastChannel := BroadcastChannel[*ServerSentEvent]{}
-
-	a.AddCustomRoute(chi.Route{
-		Pattern: pattern,
-		Handlers: map[string]http.Handler{
-			http.MethodGet: a.HandleServerSentEvents(&eventsBroadcastChannel),
-		},
-	})
-
-	return eventsBroadcastChannel.GetInputChannel()
-}
-
-// HandleServerSentEvents is a handler function that will listen on the provided channel and write events
-// to the HTTP response
-func (a *API[T]) HandleServerSentEvents(EventsBroadcastChannel *BroadcastChannel[*ServerSentEvent]) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		events := EventsBroadcastChannel.GetListener()
-		defer EventsBroadcastChannel.RemoveListener(events)
-		w.Header().Set("Cache-Control", "no-cache")
-		w.Header().Set("Connection", "keep-alive")
-		w.Header().Set("Content-Type", "text/event-stream")
-
-		for {
-			select {
-			case e := <-events:
-				e.Write(w)
-			case <-r.Context().Done():
-				return
-			case <-a.Done():
-				return
-			}
-		}
-	}
 }
 
 func Handler(do func(http.ResponseWriter, *http.Request) render.Renderer) http.HandlerFunc {

--- a/server_side_events.go
+++ b/server_side_events.go
@@ -1,0 +1,110 @@
+package babyapi
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type BroadcastChannel[T any] struct {
+	listeners []chan T
+	lock      sync.RWMutex
+}
+
+func (bc *BroadcastChannel[T]) GetListener() chan T {
+	bc.lock.Lock()
+	defer bc.lock.Unlock()
+	newChan := make(chan T)
+	bc.listeners = append(bc.listeners, newChan)
+	return newChan
+}
+
+func (bc *BroadcastChannel[T]) RemoveListener(removeChan chan T) {
+	bc.lock.Lock()
+	defer bc.lock.Unlock()
+	for i, listener := range bc.listeners {
+		if listener == removeChan {
+			bc.listeners[i] = bc.listeners[len(bc.listeners)-1]
+			bc.listeners = bc.listeners[:len(bc.listeners)-1]
+			close(listener)
+			return
+		}
+	}
+}
+
+func (bc *BroadcastChannel[T]) SendToAll(input T) {
+	bc.lock.RLock()
+	defer bc.lock.RUnlock()
+	for _, listener := range bc.listeners {
+		listener <- input
+	}
+}
+
+func (bc *BroadcastChannel[T]) runInputChannel(inputChan chan T) {
+	for input := range inputChan {
+		bc.SendToAll(input)
+	}
+}
+
+// GetInputChannel returns a channel acting as an input to the broadcast channel, closing the channel will stop the worker goroutine
+func (bc *BroadcastChannel[T]) GetInputChannel() chan T {
+	newInputChan := make(chan T)
+	go bc.runInputChannel(newInputChan)
+	return newInputChan
+}
+
+// ServerSentEvent is a simple struct that represents an event used in HTTP event stream
+type ServerSentEvent struct {
+	Event string
+	Data  string
+}
+
+// Write will write the ServerSentEvent to the HTTP response stream and flush. It removes all newlines
+// in the event data
+func (sse *ServerSentEvent) Write(w http.ResponseWriter) {
+	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", sse.Event, strings.ReplaceAll(sse.Data, "\n", ""))
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// AddServerSentEventHandler is a shortcut for HandleServerSentEvents that automatically creates and returns
+// the events channel and adds a custom handler for GET requests matching the provided pattern
+func (a *API[T]) AddServerSentEventHandler(pattern string) chan *ServerSentEvent {
+	eventsBroadcastChannel := BroadcastChannel[*ServerSentEvent]{}
+
+	a.AddCustomRoute(chi.Route{
+		Pattern: pattern,
+		Handlers: map[string]http.Handler{
+			http.MethodGet: a.HandleServerSentEvents(&eventsBroadcastChannel),
+		},
+	})
+
+	return eventsBroadcastChannel.GetInputChannel()
+}
+
+// HandleServerSentEvents is a handler function that will listen on the provided channel and write events
+// to the HTTP response
+func (a *API[T]) HandleServerSentEvents(EventsBroadcastChannel *BroadcastChannel[*ServerSentEvent]) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		events := EventsBroadcastChannel.GetListener()
+		defer EventsBroadcastChannel.RemoveListener(events)
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Content-Type", "text/event-stream")
+
+		for {
+			select {
+			case e := <-events:
+				e.Write(w)
+			case <-r.Context().Done():
+				return
+			case <-a.Done():
+				return
+			}
+		}
+	}
+}


### PR DESCRIPTION
This sholud fix issue #36 only changing the function signature of one function unlikely to be used outside of the library.

by using one chanel shared by all SSE listeners each new event will be sent only to one client at a time. In this implementation each SSE listener will get it's own channel managed by a BroadcastChannel. The BroadcastChannel will also create (as many as wanted) input channels, any message sent into one will be replicated to every listener chanel.

the test needed to be updated because the channel now will not block until read, a behavior the test depended on. The update I does cause a lot of activity passing around messages while running the test a better solution could probably be found for that, but it does properlty test behavior.

I did not add any tests for the stuct added specifically.