### PR TITLE
Fix custom response code for delete

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -102,6 +102,8 @@ func (a *API[T]) CreateClientMap(parent *Client[*AnyResource]) map[string]*Clien
 			childClient = NewSubClient[*AnyResource, *AnyResource](parent, base)
 		}
 
+		childClient.SetCustomResponseCodeMap(child.getCustomResponseCodeMap())
+
 		childMap := child.CreateClientMap(childClient)
 		for n, c := range childMap {
 			clientMap[n] = c

--- a/examples/event-rsvp/main_test.go
+++ b/examples/event-rsvp/main_test.go
@@ -252,7 +252,7 @@ func TestAPI(t *testing.T) {
 			},
 			ClientName: "Invite",
 			ExpectedResponse: babytest.ExpectedResponse{
-				Status: http.StatusNoContent,
+				Status: http.StatusOK,
 				NoBody: true,
 			},
 		},
@@ -504,7 +504,7 @@ func TestCLI(t *testing.T) {
 			},
 			ClientName: "Invite",
 			ExpectedResponse: babytest.ExpectedResponse{
-				Status: http.StatusNoContent,
+				Status: http.StatusOK,
 				NoBody: true,
 			},
 		},

--- a/related_apis.go
+++ b/related_apis.go
@@ -23,6 +23,7 @@ type relatedAPI interface {
 	RelatedAPI
 
 	setParent(relatedAPI)
+	getCustomResponseCodeMap() map[string]int
 	isRoot() bool
 }
 
@@ -51,6 +52,10 @@ func (a *API[T]) AddNestedAPI(childAPI RelatedAPI) *API[T] {
 
 func (a *API[T]) setParent(parent relatedAPI) {
 	a.parent = parent
+}
+
+func (a *API[T]) getCustomResponseCodeMap() map[string]int {
+	return a.responseCodes
 }
 
 func (a *API[T]) isRoot() bool {

--- a/router.go
+++ b/router.go
@@ -281,9 +281,7 @@ func (a *API[T]) defaultDelete() http.HandlerFunc {
 			return httpErr
 		}
 
-		render.Status(r, a.responseCodes[http.MethodDelete])
-
-		render.NoContent(w, r)
+		w.WriteHeader(a.responseCodes[http.MethodDelete])
 		return nil
 	})
 }


### PR DESCRIPTION
render.NoContent always writes 204 now on chi without respecting render.Statuc, so the custom response
code is not being respected.

This seems to only be affecting the delete handler because the others actually return content, as the others do work as expected in my testing.

This pr replaces both the call to render.Status and render.NoContent with the same function render.NoContent uses in it's implementation.