### PR TITLE
Add afterCreateOrUpdate method to API similar

### DIFF
--- a/babyapi.go
+++ b/babyapi.go
@@ -48,7 +48,8 @@ type API[T Resource] struct {
 	beforeDelete beforeAfterFunc
 	afterDelete  beforeAfterFunc
 
-	onCreateOrUpdate func(*http.Request, T) *ErrResponse
+	onCreateOrUpdate    func(*http.Request, T) *ErrResponse
+	afterCreateOrUpdate func(*http.Request, T) *ErrResponse
 
 	parent relatedAPI
 
@@ -97,6 +98,7 @@ func NewAPI[T Resource](name, base string, instance func() T) *API[T] {
 		func(*http.Request) FilterFunc[T] { return func(T) bool { return true } },
 		defaultBeforeAfter,
 		defaultBeforeAfter,
+		func(*http.Request, T) *ErrResponse { return nil },
 		func(*http.Request, T) *ErrResponse { return nil },
 		nil,
 		defaultResponseCodes(),
@@ -165,6 +167,11 @@ func (a *API[T]) SetGetAllResponseWrapper(getAllResponder func([]T) render.Rende
 // schedules or sending events
 func (a *API[T]) SetOnCreateOrUpdate(onCreateOrUpdate func(*http.Request, T) *ErrResponse) *API[T] {
 	a.onCreateOrUpdate = onCreateOrUpdate
+	return a
+}
+
+func (a *API[T]) SetAfterCreateOrUpdate(afterCreateOrUpdate func(*http.Request, T) *ErrResponse) *API[T] {
+	a.afterCreateOrUpdate = afterCreateOrUpdate
 	return a
 }
 

--- a/babyapi_test.go
+++ b/babyapi_test.go
@@ -774,6 +774,7 @@ func TestAPIModifiers(t *testing.T) {
 	beforeDelete := 0
 	afterDelete := 0
 	onCreateOrUpdate := 0
+	afterCreateOrUpdate := 0
 
 	api := babyapi.NewAPI[*Album]("Albums", "/albums", func() *Album { return &Album{} }).
 		SetCustomResponseCode(http.MethodPut, http.StatusTeapot).
@@ -785,6 +786,10 @@ func TestAPIModifiers(t *testing.T) {
 		}).
 		SetOnCreateOrUpdate(func(r *http.Request, a *Album) *babyapi.ErrResponse {
 			onCreateOrUpdate++
+			return nil
+		}).
+		SetAfterCreateOrUpdate(func(r *http.Request, a *Album) *babyapi.ErrResponse {
+			afterCreateOrUpdate++
 			return nil
 		}).
 		SetBeforeDelete(func(r *http.Request) *babyapi.ErrResponse {
@@ -848,6 +853,7 @@ func TestAPIModifiers(t *testing.T) {
 		require.Equal(t, 1, beforeDelete)
 		require.Equal(t, 1, afterDelete)
 		require.Equal(t, 1, onCreateOrUpdate)
+		require.Equal(t, 1, afterCreateOrUpdate)
 	})
 }
 

--- a/router.go
+++ b/router.go
@@ -179,6 +179,11 @@ func (a *API[T]) defaultPost() http.HandlerFunc {
 			return *new(T), InternalServerError(err)
 		}
 
+		httpErr = a.afterCreateOrUpdate(r, resource)
+		if httpErr != nil {
+			return *new(T), httpErr
+		}
+
 		render.Status(r, a.responseCodes[http.MethodPost])
 
 		return resource, nil
@@ -203,6 +208,11 @@ func (a *API[T]) defaultPut() http.HandlerFunc {
 		if err != nil {
 			logger.Error("error storing resource", "error", err)
 			return *new(T), InternalServerError(err)
+		}
+
+		httpErr = a.afterCreateOrUpdate(r, resource)
+		if httpErr != nil {
+			return *new(T), httpErr
 		}
 
 		render.Status(r, a.responseCodes[http.MethodPut])
@@ -243,6 +253,11 @@ func (a *API[T]) defaultPatch() http.HandlerFunc {
 		if err != nil {
 			logger.Error("error storing updated resource", "error", err)
 			return *new(T), InternalServerError(err)
+		}
+
+		httpErr = a.afterCreateOrUpdate(r, resource)
+		if httpErr != nil {
+			return *new(T), httpErr
 		}
 
 		render.Status(r, a.responseCodes[http.MethodPatch])


### PR DESCRIPTION
This is similar to the afterDelete, and very useful when wanting to generate a response where the resource has already been commited to the storage.

This particularly solves a problem I experienced while using SSE and uploading attached files using [cody-code-wy/babyapiFileUploadParser](https://github.com/cody-code-wy/babyapiFileUploadParser). The event would cause the page to get updated too early and the attempt ot embed the image would fail with a 404. This kind of situation can be avoided completely using this extra hook by only sending the events after everything has been saved and added to the api storage.