### PR TITLE
Add Extensions support and HATEOAS implementation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
           go-version: "1.21"
 
       - name: Test
-        run: go test -short -race -covermode=atomic -coverprofile=coverage.out -coverpkg=.,./storage,./test ./...
+        run: go test -short -race -covermode=atomic -coverprofile=coverage.out -coverpkg=.,./storage,./test,./extensions ./...
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ The client provides methods for interacting with the base API and `MakeRequest` 
 
 ## Testing
 
-`babyapi` also makes it easy to unit test your APIs with functions that start an HTTP server with routes, execute the provided request, and return the `httptest.ResponseRecorder`.
+The `babytest` package provides some shortcuts and utilities for easily building table tests or simple individual tests. This allows seamlessly creating tests for an API using the convenient `babytest.RequestTest` struct, a function returning an `*http.Request`, or a slice of command-line arguments.
 
+Check out some of the [examples](./examples) for examples of using the `babytest` package.
 
 ## Storage
 
@@ -120,6 +121,14 @@ db, err := storage.NewRedisDB(redis.Config{
 
 api.SetStorage(storage.NewClient[*TODO](db, "TODO"))
 ```
+
+## Extensions
+
+`babyapi` provides an `Extension` interface that can be applied to any API with `api.ApplyExtension()`. Implementations of this interface create custom configurations and modifications that can be applied to multiple APIs. A few extensions are provided by the `babyapi/extensions` package:
+
+  - `HATEOAS`: "Hypertext as the engine of application state" is the [3rd and final level of REST API maturity](https://en.wikipedia.org/wiki/Richardson_Maturity_Model#Level_3:_Hypermedia_controls), making your API fully RESTful
+  - `KVStorage`: provide a few simple configurations to use the `babyapi/storage` package's KV storage client with a local file or Redis
+  - `HTMX`: HTMX expects 200 responses from DELETE requests, so this changes the response code
 
 
 ## Examples

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,7 @@ tasks:
   test:
     desc: Run unit tests
     cmds:
-      - go test -short -race -covermode=atomic -coverprofile=coverage.out -coverpkg=.,./storage,./test ./...
+      - go test -short -race -covermode=atomic -coverprofile=coverage.out -coverpkg=.,./storage,./test,./extensions ./...
 
   lint:
     desc: Run linting

--- a/babyapi.go
+++ b/babyapi.go
@@ -323,3 +323,12 @@ type beforeAfterFunc func(*http.Request) *ErrResponse
 func defaultBeforeAfter(*http.Request) *ErrResponse {
 	return nil
 }
+
+// ChildAPIs returns the nested children APIs
+func (a *API[T]) ChildAPIs() map[string]RelatedAPI {
+	children := map[string]RelatedAPI{}
+	for _, child := range a.subAPIs {
+		children[child.Name()] = child
+	}
+	return children
+}

--- a/examples/todo-htmx/main.go
+++ b/examples/todo-htmx/main.go
@@ -1,16 +1,14 @@
 package main
 
 import (
-	"fmt"
 	"html/template"
 	"net/http"
 	"os"
 
 	"github.com/calvinmclean/babyapi"
-	"github.com/calvinmclean/babyapi/storage"
+	"github.com/calvinmclean/babyapi/extensions"
 
 	"github.com/go-chi/render"
-	"github.com/madflojo/hord/drivers/redis"
 )
 
 const (
@@ -133,8 +131,7 @@ func main() {
 		return AllTODOs(todos)
 	})
 
-	// HTMX requires a 200 response code to do a swap after delete
-	api.SetCustomResponseCode(http.MethodDelete, http.StatusOK)
+	api.ApplyExtension(extensions.HTMX[*TODO]{})
 
 	// Add SSE handler endpoint which will receive events on the returned channel and write them to the front-end
 	todoChan := api.AddServerSentEventHandler("/listen")
@@ -154,32 +151,14 @@ func main() {
 		return nil
 	})
 
-	err := setupStorage(api)
-	if err != nil {
-		panic(err)
-	}
+	// Optionally setup redis storage if environment variables are defined
+	api.ApplyExtension(extensions.KeyValueStorage[*TODO]{
+		KVConnectionConfig: extensions.KVConnectionConfig{
+			RedisHost:     os.Getenv("REDIS_HOST"),
+			RedisPassword: os.Getenv("REDIS_PASS"),
+			Optional:      true,
+		},
+	})
 
 	api.RunCLI()
-}
-
-// Optionally setup redis storage if environment variables are defined
-func setupStorage(api *babyapi.API[*TODO]) error {
-	host := os.Getenv("REDIS_HOST")
-	password := os.Getenv("REDIS_PASS")
-
-	if password == "" && host == "" {
-		return nil
-	}
-
-	db, err := storage.NewRedisDB(redis.Config{
-		Server:   host + ":6379",
-		Password: password,
-	})
-	if err != nil {
-		return fmt.Errorf("error setting up redis storage: %w", err)
-	}
-
-	api.Storage = storage.NewClient[*TODO](db, "TODO")
-
-	return nil
 }

--- a/examples/todo-htmx/main.go
+++ b/examples/todo-htmx/main.go
@@ -123,7 +123,7 @@ func (at AllTODOs) HTML(*http.Request) string {
 	return babyapi.MustRenderHTML(tmpl, at)
 }
 
-func main() {
+func createAPI() *babyapi.API[*TODO] {
 	api := babyapi.NewAPI[*TODO]("TODOs", "/todos", func() *TODO { return &TODO{} })
 
 	// Use AllTODOs in the GetAll response since it implements HTMLer
@@ -156,9 +156,15 @@ func main() {
 		KVConnectionConfig: extensions.KVConnectionConfig{
 			RedisHost:     os.Getenv("REDIS_HOST"),
 			RedisPassword: os.Getenv("REDIS_PASS"),
+			Filename:      os.Getenv("STORAGE_FILE"),
 			Optional:      true,
 		},
 	})
 
+	return api
+}
+
+func main() {
+	api := createAPI()
 	api.RunCLI()
 }

--- a/examples/todo-htmx/main_test.go
+++ b/examples/todo-htmx/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/calvinmclean/babyapi"
+	babytest "github.com/calvinmclean/babyapi/test"
+)
+
+func TestAPI(t *testing.T) {
+	defer os.RemoveAll("storage.json")
+
+	os.Setenv("STORAGE_FILE", "storage.json")
+	api := createAPI()
+
+	babytest.RunTableTest(t, api, []babytest.TestCase[*babyapi.AnyResource]{
+		{
+			Name: "CreateTODO",
+			Test: babytest.RequestTest[*babyapi.AnyResource]{
+				Method: http.MethodPost,
+				Body:   `{"Title": "New TODO"}`,
+			},
+			ExpectedResponse: babytest.ExpectedResponse{
+				Status:     http.StatusCreated,
+				BodyRegexp: `{"id":"[0-9a-v]{20}","Title":"New TODO","Description":"","Completed":null}`,
+			},
+		},
+		{
+			Name: "GetTODO",
+			Test: babytest.RequestTest[*babyapi.AnyResource]{
+				Method: http.MethodGet,
+				IDFunc: func(getResponse babytest.PreviousResponseGetter) string {
+					return getResponse("CreateTODO").Data.GetID()
+				},
+			},
+			ExpectedResponse: babytest.ExpectedResponse{
+				Status:     http.StatusOK,
+				BodyRegexp: `{"id":"[0-9a-v]{20}","Title":"New TODO","Description":"","Completed":null}`,
+			},
+		},
+		{
+			Name: "DeleteTODO",
+			Test: babytest.RequestTest[*babyapi.AnyResource]{
+				Method: http.MethodDelete,
+				IDFunc: func(getResponse babytest.PreviousResponseGetter) string {
+					return getResponse("CreateTODO").Data.GetID()
+				},
+			},
+			ExpectedResponse: babytest.ExpectedResponse{
+				Status: http.StatusOK,
+				NoBody: true,
+			},
+		},
+	})
+}

--- a/extensions.go
+++ b/extensions.go
@@ -1,0 +1,20 @@
+package babyapi
+
+import "fmt"
+
+// Extension is a way that a collection of modifiers, or other code, can be applied to an API all at once. This
+// makes code more reusable and allows external libraries to provide modifiers
+type Extension[T Resource] interface {
+	Apply(*API[T]) error
+}
+
+// ApplyExtension adds an Extension to the API and applies it
+func (a *API[T]) ApplyExtension(e Extension[T]) *API[T] {
+	err := e.Apply(a)
+	if err != nil {
+		// TODO: when #32 is implemented, extensions will be added to a list and applied in the function
+		// that finalizes the API and returns an error
+		panic(fmt.Sprintf("error applying extension: %v", err))
+	}
+	return a
+}

--- a/extensions/hateoas.go
+++ b/extensions/hateoas.go
@@ -1,0 +1,109 @@
+package extensions
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/calvinmclean/babyapi"
+	"github.com/go-chi/render"
+)
+
+// HATEOAS is an babyapi Extension that wraps any babyapi Resource with automatic HATEOAS style links. By default,
+// it can automatically add links for "self" and child resources when getting a resource by ID.
+// This will add the "links" field to the JSON response, so be wary of conflicting with that key. Set the LinkKey
+// to an alternative option if "links" would conflict.
+type HATEOAS[T babyapi.Resource] struct {
+	// LinkKey will override the default "links" key that the link map is represented by
+	LinkKey string
+	// CustomLinks runs as part of the Render process for responses and allows adding or overwriting links
+	CustomLinks func(*http.Request) map[string]string
+}
+
+// Apply the custom ResponseWrapper
+func (h HATEOAS[T]) Apply(api *babyapi.API[T]) error {
+	api.SetResponseWrapper(h.ResponseWrapper(api))
+
+	return nil
+}
+
+func (h HATEOAS[T]) ResponseWrapper(api *babyapi.API[T]) func(resource T) render.Renderer {
+	return func(resource T) render.Renderer {
+		childPaths := map[string]string{}
+		for _, child := range api.ChildAPIs() {
+			childPaths[child.Name()] = child.Base()
+		}
+		return &HATEOASResponse[T]{
+			resource,
+			map[string]string{},
+			childPaths,
+			h.LinkKey,
+			h.CustomLinks,
+		}
+	}
+}
+
+// HATEOASResponse wraps a babyapi Resource with additional links. The custom MarshalJSON function will handle flattening the
+// Resource so the added "links" field is at the same level as other fields of the Resource
+type HATEOASResponse[T babyapi.Resource] struct {
+	Resource T
+	Links    map[string]string `json:"links"`
+
+	childPaths  map[string]string
+	linkKey     string
+	customLinks func(*http.Request) map[string]string
+}
+
+// Render will populate the HATEOAS response with the appropriate links
+func (h *HATEOASResponse[T]) Render(w http.ResponseWriter, r *http.Request) error {
+	if h.linkKey == "" {
+		h.linkKey = "links"
+	}
+
+	self := r.URL.Path
+
+	isGetAll := r.Method == http.MethodGet && !strings.HasSuffix(self, h.Resource.GetID())
+	isPost := r.Method == http.MethodPost
+	if isPost || isGetAll {
+		self += "/" + h.Resource.GetID()
+	}
+
+	h.Links = map[string]string{
+		"self": self,
+	}
+
+	for name, path := range h.childPaths {
+		h.Links[name] = self + path
+	}
+
+	if h.customLinks != nil {
+		for name, path := range h.customLinks(r) {
+			h.Links[name] = path
+		}
+	}
+
+	return nil
+}
+
+// MarshalJSON will handle flattening the Links and Resource by marshalling separately and then combining. If the
+// Resource has its own links field, this will not work unless the LinkKey is overridden
+func (h *HATEOASResponse[T]) MarshalJSON() ([]byte, error) {
+	data, err := json.Marshal(h.Resource)
+	if err != nil {
+		return data, err
+	}
+
+	linksJSON, err := json.Marshal(h.Links)
+	if err != nil {
+		return data, err
+	}
+
+	data = data[0:bytes.LastIndex(data, []byte{'}'})]
+	data = append(data, []byte(fmt.Sprintf(`,"%s":`, h.linkKey))...)
+	data = append(data, linksJSON...)
+	data = append(data, []byte("}\n")...)
+
+	return data, nil
+}

--- a/extensions/hateoas_test.go
+++ b/extensions/hateoas_test.go
@@ -1,0 +1,224 @@
+package extensions
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/calvinmclean/babyapi"
+	babytest "github.com/calvinmclean/babyapi/test"
+
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/require"
+)
+
+type TestType struct {
+	babyapi.DefaultResource
+	FieldOne string
+}
+
+func TestHATEOASResponseRenderAndMarshal(t *testing.T) {
+	id, err := xid.FromString("cn0rbolo4027cdoo5jd0")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		input    *HATEOASResponse[*TestType]
+		method   string
+		path     string
+		expected string
+	}{
+		{
+			"SuccessfulGetNoChildren",
+			&HATEOASResponse[*TestType]{
+				Resource: &TestType{
+					DefaultResource: babyapi.DefaultResource{ID: babyapi.ID{ID: id}},
+					FieldOne:        "ValueOne",
+				},
+				Links:      map[string]string{},
+				childPaths: map[string]string{},
+				linkKey:    "links",
+			},
+			http.MethodGet,
+			"/item/cn0rbolo4027cdoo5jd0",
+			`{"id":"cn0rbolo4027cdoo5jd0","FieldOne":"ValueOne","links":{"self":"/item/cn0rbolo4027cdoo5jd0"}}`,
+		},
+		{
+			"SuccessfulGetWithChildren",
+			&HATEOASResponse[*TestType]{
+				Resource: &TestType{
+					DefaultResource: babyapi.DefaultResource{ID: babyapi.ID{ID: id}},
+					FieldOne:        "ValueOne",
+				},
+				Links: map[string]string{},
+				childPaths: map[string]string{
+					"childItem": "/children",
+				},
+			},
+			http.MethodGet,
+			"/item/cn0rbolo4027cdoo5jd0",
+			`{"id":"cn0rbolo4027cdoo5jd0","FieldOne":"ValueOne","links":{"childItem":"/item/cn0rbolo4027cdoo5jd0/children","self":"/item/cn0rbolo4027cdoo5jd0"}}`,
+		},
+		{
+			"SuccessfulPostNoChildren",
+			&HATEOASResponse[*TestType]{
+				Resource: &TestType{
+					DefaultResource: babyapi.DefaultResource{ID: babyapi.ID{ID: id}},
+					FieldOne:        "ValueOne",
+				},
+				Links:      map[string]string{},
+				childPaths: map[string]string{},
+			},
+			http.MethodPost,
+			"/item",
+			`{"id":"cn0rbolo4027cdoo5jd0","FieldOne":"ValueOne","links":{"self":"/item/cn0rbolo4027cdoo5jd0"}}`,
+		},
+		{
+			"SuccessfulPostWithChildren",
+			&HATEOASResponse[*TestType]{
+				Resource: &TestType{
+					DefaultResource: babyapi.DefaultResource{ID: babyapi.ID{ID: id}},
+					FieldOne:        "ValueOne",
+				},
+				Links: map[string]string{},
+				childPaths: map[string]string{
+					"childItem": "/children",
+				},
+			},
+			http.MethodPost,
+			"/item",
+			`{"id":"cn0rbolo4027cdoo5jd0","FieldOne":"ValueOne","links":{"childItem":"/item/cn0rbolo4027cdoo5jd0/children","self":"/item/cn0rbolo4027cdoo5jd0"}}`,
+		},
+		{
+			"SuccessfulGetWithChildrenAndCustomLinkFunction",
+			&HATEOASResponse[*TestType]{
+				Resource: &TestType{
+					DefaultResource: babyapi.DefaultResource{ID: babyapi.ID{ID: id}},
+					FieldOne:        "ValueOne",
+				},
+				Links: map[string]string{},
+				childPaths: map[string]string{
+					"childItem": "/children",
+				},
+				customLinks: func(r *http.Request) map[string]string {
+					return map[string]string{
+						"new": "/link",
+					}
+				},
+			},
+			http.MethodGet,
+			"/item/cn0rbolo4027cdoo5jd0",
+			`{"id":"cn0rbolo4027cdoo5jd0","FieldOne":"ValueOne","links":{"childItem":"/item/cn0rbolo4027cdoo5jd0/children","new":"/link","self":"/item/cn0rbolo4027cdoo5jd0"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err = tt.input.Render(nil, &http.Request{Method: tt.method, URL: &url.URL{Path: tt.path}})
+			require.NoError(t, err)
+
+			data, err := json.Marshal(tt.input)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expected, string(data))
+		})
+	}
+}
+
+func TestAPIWithExtension(t *testing.T) {
+	api := babyapi.NewAPI[*TestType]("Test", "/item", func() *TestType { return &TestType{} })
+	childAPI := babyapi.NewAPI[*TestType]("Child", "/child", func() *TestType { return &TestType{} })
+
+	ext := HATEOAS[*TestType]{}
+	_ = ext.Apply(api)
+	// TODO: real extension mechanism will allow control over applying children?
+	_ = ext.Apply(childAPI)
+
+	// Add nested API after applying extension to make sure it still works
+	api.AddNestedAPI(childAPI)
+
+	babytest.RunTableTest(t, api, []babytest.TestCase[*babyapi.AnyResource]{
+		{
+			Name: "CreateParent",
+			Test: babytest.RequestTest[*babyapi.AnyResource]{
+				Method: http.MethodPost,
+				Body:   `{"FieldOne": "ValueOne"}`,
+			},
+			ExpectedResponse: babytest.ExpectedResponse{
+				Status:     http.StatusCreated,
+				BodyRegexp: `{"id":"[0-9a-v]{20}","FieldOne":"ValueOne","links":{"Child":"/item/[0-9a-v]{20}/child","self":"/item/[0-9a-v]{20}"}}`,
+			},
+		},
+		{
+			Name: "GetParent",
+			Test: babytest.RequestTest[*babyapi.AnyResource]{
+				Method: http.MethodGet,
+				IDFunc: func(getResponse babytest.PreviousResponseGetter) string {
+					return getResponse("CreateParent").Data.GetID()
+				},
+			},
+			ExpectedResponse: babytest.ExpectedResponse{
+				Status:     http.StatusOK,
+				BodyRegexp: `{"id":"[0-9a-v]{20}","FieldOne":"ValueOne","links":{"Child":"/item/[0-9a-v]{20}/child","self":"/item/[0-9a-v]{20}"}}`,
+			},
+		},
+		{
+			Name: "GetAllParents",
+			Test: babytest.RequestTest[*babyapi.AnyResource]{
+				Method: babytest.MethodGetAll,
+			},
+			ExpectedResponse: babytest.ExpectedResponse{
+				Status:     http.StatusOK,
+				BodyRegexp: `{"items":\[{"id":"[0-9a-v]{20}","FieldOne":"ValueOne","links":{"Child":"/item/[0-9a-v]{20}/child","self":"/item/[0-9a-v]{20}"}}\]}`,
+			},
+		},
+		{
+			Name: "CreateChild",
+			Test: babytest.RequestTest[*babyapi.AnyResource]{
+				Method: http.MethodPost,
+				ParentIDsFunc: func(getResponse babytest.PreviousResponseGetter) []string {
+					return []string{getResponse("CreateParent").Data.GetID()}
+				},
+				Body: `{"FieldOne": "ValueOne"}`,
+			},
+			ClientName: "Child",
+			ExpectedResponse: babytest.ExpectedResponse{
+				Status:     http.StatusCreated,
+				BodyRegexp: `{"id":"[0-9a-v]{20}","FieldOne":"ValueOne","links":{"self":"/item/[0-9a-v]{20}/child/[0-9a-v]{20}"}}`,
+			},
+		},
+		{
+			Name: "GetChild",
+			Test: babytest.RequestTest[*babyapi.AnyResource]{
+				Method: http.MethodGet,
+				ParentIDsFunc: func(getResponse babytest.PreviousResponseGetter) []string {
+					return []string{getResponse("CreateParent").Data.GetID()}
+				},
+				IDFunc: func(getResponse babytest.PreviousResponseGetter) string {
+					return getResponse("CreateChild").Data.GetID()
+				},
+				Body: `{"FieldOne": "ValueOne"}`,
+			},
+			ClientName: "Child",
+			ExpectedResponse: babytest.ExpectedResponse{
+				Status:     http.StatusOK,
+				BodyRegexp: `{"id":"[0-9a-v]{20}","FieldOne":"ValueOne","links":{"self":"/item/[0-9a-v]{20}/child/[0-9a-v]{20}"}}`,
+			},
+		},
+		{
+			Name: "GetAllChildren",
+			Test: babytest.RequestTest[*babyapi.AnyResource]{
+				Method: babytest.MethodGetAll,
+				ParentIDsFunc: func(getResponse babytest.PreviousResponseGetter) []string {
+					return []string{getResponse("CreateParent").Data.GetID()}
+				},
+			},
+			ClientName: "Child",
+			ExpectedResponse: babytest.ExpectedResponse{
+				Status:     http.StatusOK,
+				BodyRegexp: `{"items":\[{"id":"[0-9a-v]{20}","FieldOne":"ValueOne","links":{"self":"/item/[0-9a-v]{20}/child/[0-9a-v]{20}"}}\]}`,
+			},
+		},
+	})
+}

--- a/extensions/hateoas_test.go
+++ b/extensions/hateoas_test.go
@@ -131,9 +131,8 @@ func TestAPIWithExtension(t *testing.T) {
 	childAPI := babyapi.NewAPI[*TestType]("Child", "/child", func() *TestType { return &TestType{} })
 
 	ext := HATEOAS[*TestType]{}
-	_ = ext.Apply(api)
-	// TODO: real extension mechanism will allow control over applying children?
-	_ = ext.Apply(childAPI)
+	api.ApplyExtension(ext)
+	childAPI.ApplyExtension(ext)
 
 	// Add nested API after applying extension to make sure it still works
 	api.AddNestedAPI(childAPI)

--- a/extensions/htmx.go
+++ b/extensions/htmx.go
@@ -1,0 +1,16 @@
+package extensions
+
+import (
+	"net/http"
+
+	"github.com/calvinmclean/babyapi"
+)
+
+// HTMX is a shortcut to apply HTMX compatibility. Currently this just sets a 200 response on Delete
+type HTMX[T babyapi.Resource] struct{}
+
+func (HTMX[T]) Apply(api *babyapi.API[T]) error {
+	// HTMX requires a 200 response code to do a swap after delete
+	api.SetCustomResponseCode(http.MethodDelete, http.StatusOK)
+	return nil
+}

--- a/extensions/kv_storage.go
+++ b/extensions/kv_storage.go
@@ -1,0 +1,81 @@
+package extensions
+
+import (
+	"fmt"
+
+	"github.com/calvinmclean/babyapi"
+	"github.com/calvinmclean/babyapi/storage"
+	"github.com/madflojo/hord"
+	"github.com/madflojo/hord/drivers/hashmap"
+	"github.com/madflojo/hord/drivers/redis"
+)
+
+// KeyValueStorage sets up a connection to Redis or local file storage and applies to the API's Storage Client
+// If you pass environment variables for configurations, this can dynamically determine filesystem or Redis
+// storage based on the available configs
+type KeyValueStorage[T babyapi.Resource] struct {
+	// Optional key to use as a prefix when storing in key-value store. If empty, api Name is used
+	StorageKeyPrefix string
+
+	// KVConnectionConfig has connection data for KV store. Optional if DB is provided
+	KVConnectionConfig
+
+	// DB is the database connection. It is created if not provided. This is useful if multiple APIs share
+	// a storage backend
+	DB hord.Database
+}
+
+type KVConnectionConfig struct {
+	// Filename to write JSON data to
+	Filename string
+
+	// Host of Redis instance
+	RedisHost string
+	// Password for Redis instance
+	RedisPassword string
+
+	// If other configurations are empty, this will not return an error and skips setting api Storage.
+	// This is useful if using env vars as the values for configs
+	Optional bool
+}
+
+func (h KeyValueStorage[T]) Apply(api *babyapi.API[T]) error {
+	db := h.DB
+	if db == nil {
+		var err error
+		db, err = h.CreateDB()
+		if err != nil {
+			return fmt.Errorf("error creating database connection: %w", err)
+		}
+	}
+	if db == nil && h.Optional {
+		return nil
+	}
+
+	storageKeyPrefix := h.StorageKeyPrefix
+	if storageKeyPrefix == "" {
+		storageKeyPrefix = api.Name()
+	}
+
+	api.Storage = storage.NewClient[T](db, storageKeyPrefix)
+
+	return nil
+}
+
+func (h KVConnectionConfig) CreateDB() (hord.Database, error) {
+	switch {
+	case h.RedisHost != "" && h.RedisPassword != "":
+		return storage.NewRedisDB(redis.Config{
+			Server:   h.RedisHost + ":6379",
+			Password: h.RedisPassword,
+		})
+	case h.Filename != "":
+		return storage.NewFileDB(hashmap.Config{
+			Filename: h.Filename,
+		})
+	case h.Optional:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("filename or redis configuration is required")
+	}
+}


### PR DESCRIPTION
This PR adds a few things:
- Extension support using `ApplyExtension` and `Extension` interface. This allows more reusable code and creating external extensions
- Add HATEOAS extension to automatically create links and create a fully RESTful API