### PR TITLE
Lock API modifiers after starting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,8 @@ on:
       - main
 
 jobs:
-  golangci:
-    name: lint
+  lint_and_check:
+    name: lint_and_check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -19,6 +19,12 @@ jobs:
         with:
           go-version: "1.21"
           cache: false
+
+      - name: run generate command
+        run: go generate ./...
+
+      - name: fail if generate causes changes
+        run: git diff --exit-code
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/babyapi.go
+++ b/babyapi.go
@@ -75,6 +75,8 @@ type API[T Resource] struct {
 	Delete http.HandlerFunc
 
 	rootAPI bool
+
+	readOnly bool
 }
 
 // NewAPI initializes an API using the provided name, base URL path, and function to create a new instance of
@@ -109,6 +111,7 @@ func NewAPI[T Resource](name, base string, instance func() T) *API[T] {
 		nil,
 		nil,
 		nil,
+		false,
 		false,
 	}
 

--- a/babyapi.go
+++ b/babyapi.go
@@ -2,6 +2,7 @@ package babyapi
 
 import (
 	"context"
+	"errors"
 	"log"
 	"log/slog"
 	"net/http"
@@ -364,6 +365,6 @@ func (a *API[T]) ChildAPIs() map[string]RelatedAPI {
 
 func (a *API[T]) panicIfReadOnly() {
 	if a.readOnly {
-		panic("API cannot be modified after starting")
+		panic(errors.New("API cannot be modified after starting"))
 	}
 }

--- a/babyapi_test.go
+++ b/babyapi_test.go
@@ -1341,3 +1341,15 @@ func TestRootAPICLI(t *testing.T) {
 		})
 	}
 }
+
+func TestReadOnlyPanicAfterStart(t *testing.T) {
+	api := babyapi.NewAPI[*Album]("Albums", "/albums", func() *Album { return &Album{} })
+
+	_ = api.Router()
+
+	require.PanicsWithError(t, "API cannot be modified after starting", func() {
+		api.SetOnCreateOrUpdate(func(_ *http.Request, _ *Album) *babyapi.ErrResponse {
+			return nil
+		})
+	})
+}

--- a/cmd/generate_readonly/main.go
+++ b/cmd/generate_readonly/main.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+// TODO: generate tests using each modifier name and generate tests?
+
+const panicFuncName = "panicIfReadOnly"
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run main.go <directory>")
+		os.Exit(1)
+	}
+
+	dir := os.Args[1]
+
+	// read the files in the specified directory
+	files, err := filepath.Glob(filepath.Join(dir, "*.go"))
+	if err != nil {
+		fmt.Println("Error reading directory:", err)
+		os.Exit(1)
+	}
+
+	// parse the expression to easily insert
+	generatedExpr, err := parser.ParseExpr(fmt.Sprintf("a.%s()\n", panicFuncName))
+	if err != nil {
+		fmt.Println("Error reading directory:", err)
+		os.Exit(1)
+	}
+
+	// parse each Go source file
+	for _, file := range files {
+		err = addReadOnlyPanicToFile(file, generatedExpr)
+		if err != nil {
+			fmt.Println("error parsing/editing file:", err)
+		}
+	}
+}
+
+func addReadOnlyPanicToFile(filename string, generatedExpr ast.Expr) error {
+	fset := token.NewFileSet()
+
+	node, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
+	if err != nil {
+		return fmt.Errorf("error parsing file: %w", err)
+	}
+
+	astutil.Apply(node, nil, func(c *astutil.Cursor) bool {
+		funcDecl, ok := c.Node().(*ast.FuncDecl)
+		if !ok {
+			return true
+		}
+
+		recvType := getFuncReceiverType(funcDecl)
+		returnType := getFuncReturnType(funcDecl)
+
+		// exit if there is no receiver or return
+		if recvType == nil || returnType == nil {
+			return true
+		}
+
+		if !(isAPIType(recvType) && isAPIType(returnType)) {
+			return true
+		}
+
+		if alreadyGenerated(funcDecl.Body.List) {
+			return true
+		}
+
+		funcDecl.Body.List = append([]ast.Stmt{&ast.ExprStmt{
+			X: generatedExpr,
+		}}, funcDecl.Body.List...)
+
+		c.Replace(funcDecl)
+
+		return true
+	})
+
+	outputFile, err := os.OpenFile(filename, os.O_RDWR, 0644)
+	if err != nil {
+		return fmt.Errorf("error opening output file: %w", err)
+	}
+	defer outputFile.Close()
+
+	err = format.Node(outputFile, fset, &printer.CommentedNode{Node: node})
+	if err != nil {
+		return fmt.Errorf("error writing file: %w", err)
+	}
+
+	return nil
+}
+
+func getFuncReturnType(f *ast.FuncDecl) *ast.StarExpr {
+	if f.Type == nil || f.Type.Results == nil {
+		return nil
+	}
+
+	returnType, _ := f.Type.Results.List[0].Type.(*ast.StarExpr)
+	return returnType
+}
+
+func getFuncReceiverType(f *ast.FuncDecl) *ast.StarExpr {
+	if f.Recv == nil || len(f.Recv.List) != 1 {
+		return nil
+	}
+
+	recvType, _ := f.Recv.List[0].Type.(*ast.StarExpr)
+	return recvType
+}
+
+func alreadyGenerated(bodyList []ast.Stmt) bool {
+	for _, item := range bodyList {
+		exprStmt, ok := item.(*ast.ExprStmt)
+		if !ok {
+			continue
+		}
+
+		callExpr, ok := exprStmt.X.(*ast.CallExpr)
+		if !ok {
+			continue
+		}
+
+		sel, ok := callExpr.Fun.(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+
+		if sel.Sel.Name == panicFuncName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isAPIType(input *ast.StarExpr) bool {
+	idx, ok := input.X.(*ast.IndexExpr)
+	if !ok {
+		return false
+	}
+
+	ident, ok := idx.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+
+	genIdent, ok := idx.Index.(*ast.Ident)
+	if !ok {
+		return false
+	}
+
+	recvType := ident.Name
+	genType := genIdent.Name
+
+	return recvType == "API" && genType == "T"
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,3 +12,4 @@ coverage:
 
 ignore:
   - examples
+  - cmd

--- a/extensions.go
+++ b/extensions.go
@@ -10,6 +10,8 @@ type Extension[T Resource] interface {
 
 // ApplyExtension adds an Extension to the API and applies it
 func (a *API[T]) ApplyExtension(e Extension[T]) *API[T] {
+	a.panicIfReadOnly()
+
 	err := e.Apply(a)
 	if err != nil {
 		// TODO: when #32 is implemented, extensions will be added to a list and applied in the function

--- a/gen.go
+++ b/gen.go
@@ -1,0 +1,3 @@
+package babyapi
+
+//go:generate go run cmd/generate_readonly/main.go .

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/rs/xid v1.5.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
+	golang.org/x/tools v0.15.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,12 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa h1:FRnLl4eNAQl8hwxVVC17teOw8kdjVDVAiFMtgUdTSRQ=
 golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa/go.mod h1:zk2irFbV9DP96SEBUUAy67IdHUaZuSnrz1n472HUCLE=
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/tools v0.15.0 h1:zdAyfUGbYmuVokhzVmghFl2ZJh5QhcfebBgmVPFYA+8=
+golang.org/x/tools v0.15.0/go.mod h1:hpksKq4dtpQWS1uQ61JkdqWM3LscIS6Slf+VVkm+wQk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/related_apis.go
+++ b/related_apis.go
@@ -39,6 +39,8 @@ func (a *API[T]) GetParentIDParam(r *http.Request) string {
 
 // AddNestedAPI adds a child API to this API and initializes the parent relationship on the child's side
 func (a *API[T]) AddNestedAPI(childAPI RelatedAPI) *API[T] {
+	a.panicIfReadOnly()
+
 	relAPI, ok := childAPI.(relatedAPI)
 	if !ok {
 		panic(fmt.Sprintf("incompatible type for child API: %T", childAPI))

--- a/router.go
+++ b/router.go
@@ -30,9 +30,9 @@ type HTMLer interface {
 
 // Create API routes on the given router
 func (a *API[T]) Route(r chi.Router) {
-	respondOnce.Do(func() {
-		a.readOnly = true
+	a.readOnly.TryLock()
 
+	respondOnce.Do(func() {
 		render.Respond = func(w http.ResponseWriter, r *http.Request, v interface{}) {
 			if render.GetAcceptedContentType(r) == render.ContentTypeHTML {
 				htmler, ok := v.(HTMLer)

--- a/router.go
+++ b/router.go
@@ -30,9 +30,9 @@ type HTMLer interface {
 
 // Create API routes on the given router
 func (a *API[T]) Route(r chi.Router) {
-	a.readOnly = true
-
 	respondOnce.Do(func() {
+		a.readOnly = true
+
 		render.Respond = func(w http.ResponseWriter, r *http.Request, v interface{}) {
 			if render.GetAcceptedContentType(r) == render.ContentTypeHTML {
 				htmler, ok := v.(HTMLer)

--- a/router.go
+++ b/router.go
@@ -30,6 +30,8 @@ type HTMLer interface {
 
 // Create API routes on the given router
 func (a *API[T]) Route(r chi.Router) {
+	a.readOnly = true
+
 	respondOnce.Do(func() {
 		render.Respond = func(w http.ResponseWriter, r *http.Request, v interface{}) {
 			if render.GetAcceptedContentType(r) == render.ContentTypeHTML {


### PR DESCRIPTION
Partial for #32 by locking modifiers after start.

Adds generator to enforce this in new modifiers and check they are valid during lint stage