### PR TITLE
Add error handling for modifiers

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -55,8 +55,7 @@ func (a *API[T]) RunWithArgs(out io.Writer, args []string, bindAddress string, a
 	}
 
 	if args[0] == "serve" {
-		a.Serve(bindAddress)
-		return nil
+		return a.Serve(bindAddress)
 	}
 
 	return a.runClientCLI(out, args, address, pretty, headers, query)

--- a/extensions.go
+++ b/extensions.go
@@ -14,9 +14,8 @@ func (a *API[T]) ApplyExtension(e Extension[T]) *API[T] {
 
 	err := e.Apply(a)
 	if err != nil {
-		// TODO: when #32 is implemented, extensions will be added to a list and applied in the function
-		// that finalizes the API and returns an error
-		panic(fmt.Sprintf("error applying extension: %v", err))
+		a.errors = append(a.errors, fmt.Errorf("ApplyExtension: error applying extension: %w", err))
+		return a
 	}
 	return a
 }

--- a/related_apis.go
+++ b/related_apis.go
@@ -10,8 +10,8 @@ import (
 // RelatedAPI declares a subset of methods from the API struct that are required to enable
 // nested/parent-child API relationships
 type RelatedAPI interface {
-	Router() chi.Router
-	Route(chi.Router)
+	Router() (chi.Router, error)
+	Route(chi.Router) error
 	Base() string
 	Name() string
 	GetIDParam(*http.Request) string
@@ -43,7 +43,8 @@ func (a *API[T]) AddNestedAPI(childAPI RelatedAPI) *API[T] {
 
 	relAPI, ok := childAPI.(relatedAPI)
 	if !ok {
-		panic(fmt.Sprintf("incompatible type for child API: %T", childAPI))
+		a.errors = append(a.errors, fmt.Errorf("AddNestedAPI: incompatible type for child API: %T", childAPI))
+		return a
 	}
 
 	a.subAPIs[childAPI.Name()] = relAPI


### PR DESCRIPTION
- Modifiers can append to errors slice that is checked when creating routes
- This allows for cleaner error handling when building APIs and could enable dynamically creating APIs at runtime without panic risk

Closes #32